### PR TITLE
Removes PresentationCore dependency

### DIFF
--- a/CTRE.Phoenix.dotNET/CTRE.Phoenix.dotNET.csproj
+++ b/CTRE.Phoenix.dotNET/CTRE.Phoenix.dotNET.csproj
@@ -31,7 +31,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -58,7 +57,7 @@
     <Compile Include="Form\ToolTipContainer.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/CTRE.Phoenix.dotNET/Form/FormRoutines.cs
+++ b/CTRE.Phoenix.dotNET/Form/FormRoutines.cs
@@ -29,7 +29,7 @@ namespace CTRE.Phoenix.dotNET.Form
         {
             try
             {
-                System.Windows.Clipboard.SetText(toCopy, System.Windows.TextDataFormat.Text);
+                System.Windows.Forms.Clipboard.SetText(toCopy, System.Windows.Forms.TextDataFormat.Text);
                 return true;
             }
             catch (Exception)
@@ -41,7 +41,7 @@ namespace CTRE.Phoenix.dotNET.Form
         {
             try
             {
-                System.Windows.Clipboard.SetDataObject(objToCopy, true);
+                System.Windows.Forms.Clipboard.SetDataObject(objToCopy, true);
                 return true;
             }
             catch (Exception)

--- a/CTRE_Phoenix_GUI_Dashboard/CTRE_Phoenix_GUI_Dashboard.csproj
+++ b/CTRE_Phoenix_GUI_Dashboard/CTRE_Phoenix_GUI_Dashboard.csproj
@@ -121,7 +121,7 @@
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>


### PR DESCRIPTION
If ILMerge is wanted to be supported in the future, the project can contain no WPF dependencies. However, this is a trivial change, and since this is forms we should be using the forms version anyway