### PR TITLE
Consistent formatting for object and string

### DIFF
--- a/CTRE.Phoenix.Diagnostics/BackEnd/BackEnd.cs
+++ b/CTRE.Phoenix.Diagnostics/BackEnd/BackEnd.cs
@@ -30,9 +30,9 @@ namespace CTRE.Phoenix.Diagnostics.BackEnd
         private HostNameAndPort _hostName = new HostNameAndPort();
         private DeviceDescriptors _descriptors = new DeviceDescriptors();
         private State _state = State.Connecting;
-        private Object _lock = new Object();
+        private object _lock = new object();
         private Thread _thread;
-        private string _ConnectionStatus = String.Empty;
+        private string _ConnectionStatus = string.Empty;
         private Action _action;
         private uint _timeSincePollingMs = uint.MaxValue / 2;
         private uint _timeSinceSomeElsesToolTransmit = uint.MaxValue / 2;
@@ -59,7 +59,7 @@ namespace CTRE.Phoenix.Diagnostics.BackEnd
         public struct FirmwareStatus
         {
             public uint progressPerc;
-            public String message;
+            public string message;
         }
         public FirmwareStatus _firmwareStatus;
 
@@ -200,7 +200,7 @@ namespace CTRE.Phoenix.Diagnostics.BackEnd
 
                 case ActionType.SetDeviceName:
                     /* get params for this action */
-                    String newName = _action.stringParam;
+                    string newName = _action.stringParam;
                     /* make sure device was found in our collection */
                     if (retval == Status.Ok)
                         retval = (foundOk) ? Status.Ok : Status.DeviceNotFound;
@@ -392,7 +392,7 @@ namespace CTRE.Phoenix.Diagnostics.BackEnd
         {
             /* attempt requesting an update */
             string response;
-            Status retval = _WebServerScripts.HttpGet(_hostName, "", 0, ActionType.GetVersion, out response, String.Empty, 1000);
+            Status retval = _WebServerScripts.HttpGet(_hostName, "", 0, ActionType.GetVersion, out response, string.Empty, 1000);
 
             /* attempt parsing */
             VersionReturn general = null;
@@ -426,7 +426,7 @@ namespace CTRE.Phoenix.Diagnostics.BackEnd
         {
             /* attempt requesting an update */
             string response;
-            Status retval = _WebServerScripts.HttpGet(_hostName, "", 0, ActionType.GetDeviceList, out response, String.Empty, 2000);
+            Status retval = _WebServerScripts.HttpGet(_hostName, "", 0, ActionType.GetDeviceList, out response, string.Empty, 2000);
 
             /* attempt parsing */
             GetDevicesReturn deviceStatus = null;
@@ -699,12 +699,12 @@ namespace CTRE.Phoenix.Diagnostics.BackEnd
         }
 
         //------------------------------- Routines for getting status of BackEnd, these routines must not block -------------------------------------//
-        public String GetConnectionStatus()
+        public string GetConnectionStatus()
         {
             /* return the last rendered tool status from our backEnd Thread */
             return _ConnectionStatus;
         }
-        public State GetStatus(out String message, out String messageColor, out String hoverMsg)
+        public State GetStatus(out string message, out string messageColor, out string hoverMsg)
         {
             State retval = GetState_NoLock();
 
@@ -944,7 +944,7 @@ namespace CTRE.Phoenix.Diagnostics.BackEnd
             Action ac = new Action(callback, dd, ActionType.SelfTest);
             return PushAction(ac);
         }
-        public Status RequestChangeName(DeviceDescrip dd, String newName, Action.CallBack callback)
+        public Status RequestChangeName(DeviceDescrip dd, string newName, Action.CallBack callback)
         {
             Action ac = new Action(callback, dd, ActionType.SetDeviceName);
             ac.stringParam = newName;
@@ -1014,7 +1014,7 @@ namespace CTRE.Phoenix.Diagnostics.BackEnd
             return PushAction(ac);
         }
         //------------ HOST selection ---------------//
-        public Status SetHostName(String hostNewName, String hostPort)
+        public Status SetHostName(string hostNewName, string hostPort)
         {
             _hostName.Set(hostNewName, hostPort);
             return Status.Ok;

--- a/CTRE.Phoenix.Diagnostics/BackEnd/BackEnd_Flashing.cs
+++ b/CTRE.Phoenix.Diagnostics/BackEnd/BackEnd_Flashing.cs
@@ -10,7 +10,7 @@ namespace CTRE.Phoenix.Diagnostics.BackEnd
     {
         private Status ConfirmIfFieldUpgradeIsOccuring(DeviceDescrip ddRef, bool bExpectToBeFlashing)
         {
-            String response = String.Empty;
+            string response = string.Empty;
             Status retval = Status.Ok;
 
             /* get status update */
@@ -48,7 +48,7 @@ namespace CTRE.Phoenix.Diagnostics.BackEnd
 
         private Status CheckAsyncWebServerResp(AsyncWebExchange asyncWebExchange, int timeoutMs, out bool isDone)
         {
-            String response = String.Empty;
+            string response = string.Empty;
             Status retval = Status.Ok;
 
             isDone = false;
@@ -94,7 +94,7 @@ namespace CTRE.Phoenix.Diagnostics.BackEnd
         private Status ExecuteFieldUpgrade(DeviceDescrip ddRef, AsyncWebExchange asyncWebExchange, string fileName, bool usingSftp)
         {
             Status retval = Status.Ok;
-            String response = string.Empty;
+            string response = string.Empty;
 
             /* let user know action is being processed */
             SetFieldUpgradeStatus("Reading CRF...", 0);

--- a/CTRE.Phoenix.Diagnostics/HTTP/Telemetry.cs
+++ b/CTRE.Phoenix.Diagnostics/HTTP/Telemetry.cs
@@ -13,14 +13,14 @@ namespace CTRE.Phoenix.Diagnostics.HTTP
         public class ExchangeLog
         {
             public int lineNumber;
-            public String type;
-            public String request;
-            public String response;
+            public string type;
+            public string request;
+            public string response;
             public ActionType actionType;
 
             private static int counter = 0;
 
-            public ExchangeLog(String type, String request, String response, ActionType actionType)
+            public ExchangeLog(string type, string request, string response, ActionType actionType)
             {
                 this.lineNumber = ++counter;
                 this.type = type;

--- a/CTRE.Phoenix.Diagnostics/HostNameAndPort.cs
+++ b/CTRE.Phoenix.Diagnostics/HostNameAndPort.cs
@@ -4,11 +4,11 @@ namespace CTRE.Phoenix.Diagnostics
 {
     public class HostNameAndPort
     {
-        private String _name = String.Empty;
-        private String _port = String.Empty;
+        private string _name = string.Empty;
+        private string _port = string.Empty;
 
-        private String _newName = String.Empty;
-        private String _newPort = String.Empty;
+        private string _newName = string.Empty;
+        private string _newPort = string.Empty;
 
         private bool _changed = false;
 

--- a/CTRE.Phoenix.Diagnostics/RioUpdater.cs
+++ b/CTRE.Phoenix.Diagnostics/RioUpdater.cs
@@ -13,7 +13,7 @@ namespace CTRE.Phoenix.Diagnostics
         private bool _isStopped = false;
         private int _error = 0;
         private StringBuilder _sb = new StringBuilder();
-        private readonly Object _lock = new Object();
+        private readonly object _lock = new object();
         private bool _started;
         HostNameAndPort _host;
 
@@ -247,7 +247,7 @@ namespace CTRE.Phoenix.Diagnostics
                 sb.Clear();
                 _started = false;
             }
-            String temp = string.Empty;
+            string temp = string.Empty;
             bool retval = false;
             /* lock and copy */
             lock (_lock)
@@ -278,7 +278,7 @@ namespace CTRE.Phoenix.Diagnostics
                 _error = error;
             }
         }
-        public void Log(String s)
+        public void Log(string s)
         {
             lock (_lock)
             {
@@ -487,7 +487,7 @@ namespace CTRE.Phoenix.Diagnostics
             OnFinished(error);
             stopWatch.Stop();
             TimeSpan ts = stopWatch.Elapsed;
-            string elapsedTime = String.Format("{0:00}:{1:00}:{2:00}.{3:00}",
+            string elapsedTime = string.Format("{0:00}:{1:00}:{2:00}.{3:00}",
                 ts.Hours, ts.Minutes, ts.Seconds,
                 ts.Milliseconds / 10);
             Log("\nDuration: " + elapsedTime);
@@ -604,7 +604,7 @@ namespace CTRE.Phoenix.Diagnostics
             OnFinished(error);
             stopWatch.Stop();
             TimeSpan ts = stopWatch.Elapsed;
-            string elapsedTime = String.Format("{0:00}:{1:00}:{2:00}.{3:00}",
+            string elapsedTime = string.Format("{0:00}:{1:00}:{2:00}.{3:00}",
                 ts.Hours, ts.Minutes, ts.Seconds,
                 ts.Milliseconds / 10);
             Log("\nDuration: " + elapsedTime);

--- a/CTRE.Phoenix.dotNET/Debug.cs
+++ b/CTRE.Phoenix.dotNET/Debug.cs
@@ -14,7 +14,7 @@ namespace CTRE.Phoenix.dotNET
                 Print("Assert","Assert failed");
             }
         }
-        public static void Print(String tag, String message)
+        public static void Print(string tag, string message)
         {
             long milliseconds = DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
             milliseconds -= _bootTime;

--- a/CTRE.Phoenix.dotNET/Form/BottomStatusBar.cs
+++ b/CTRE.Phoenix.dotNET/Form/BottomStatusBar.cs
@@ -29,32 +29,32 @@ namespace CTRE.Phoenix.dotNET.Form
             {
                 if (label != null)
                 {
-                    label.Text = String.Empty;
+                    label.Text = string.Empty;
                 }
             }
 
             _tooltip = new CTRE.Phoenix.dotNET.Form.ToolTipContainer(statusStrip);
         }
-        public void SetHoverString(String hoverMsg)
+        public void SetHoverString(string hoverMsg)
         {
             _tooltip.SetText(hoverMsg);
         }
-        public void PrintLeft(Color col, String text)
+        public void PrintLeft(Color col, string text)
         {
             _labels[0].ForeColor = col;
             _labels[0].Text = text;
         }
-        public void PrintMiddleLeft(Color col, String text)
+        public void PrintMiddleLeft(Color col, string text)
         {
             _labels[1].ForeColor = col;
             _labels[1].Text = text;
         }
-        public void PrintMiddleRight(Color col, String text)
+        public void PrintMiddleRight(Color col, string text)
         {
             _labels[2].ForeColor = col;
             _labels[2].Text = text;
         }
-        public void PrintRight(Color col, String text)
+        public void PrintRight(Color col, string text)
         {
             _labels[3].ForeColor = col;
             _labels[3].Text = text;

--- a/CTRE.Phoenix.dotNET/Form/FastUpdate.cs
+++ b/CTRE.Phoenix.dotNET/Form/FastUpdate.cs
@@ -42,13 +42,13 @@ namespace CTRE.Phoenix.dotNET.Form
         }
 
         //--------------- Static routines for lazy updating ----------//
-        public static void AssignIfDiff(ListViewItem.ListViewSubItem lhs, String rhs)
+        public static void AssignIfDiff(ListViewItem.ListViewSubItem lhs, string rhs)
         {
             if (lhs.Text.Equals(rhs)) { }
             else { lhs.Text = rhs; }
         }
 
-        public static void AssignIfDiff(System.Windows.Forms.Label lhs, String rhs)
+        public static void AssignIfDiff(System.Windows.Forms.Label lhs, string rhs)
         {
             if (lhs.Text.Equals(rhs)) { }
             else { lhs.Text = rhs; }
@@ -58,7 +58,7 @@ namespace CTRE.Phoenix.dotNET.Form
             if (lhs.BackColor.Equals(rhs)) { }
             else { lhs.BackColor = rhs; }
         }
-        public static void AssignIfDiff(System.Windows.Forms.GroupBox lhs, String rhs)
+        public static void AssignIfDiff(System.Windows.Forms.GroupBox lhs, string rhs)
         {
             if (lhs.Text.Equals(rhs)) { }
             else { lhs.Text = rhs; }

--- a/CTRE.Phoenix.dotNET/Form/FormRoutines.cs
+++ b/CTRE.Phoenix.dotNET/Form/FormRoutines.cs
@@ -5,14 +5,14 @@ namespace CTRE.Phoenix.dotNET.Form
 {
     public static class FormRoutines
     {
-        public static String GetAppVersion()
+        public static string GetAppVersion()
         {
             System.Reflection.Assembly assembly = System.Reflection.Assembly.GetExecutingAssembly();
             System.Diagnostics.FileVersionInfo fvi = System.Diagnostics.FileVersionInfo.GetVersionInfo(assembly.Location);
             string version = fvi.FileVersion;
             return version;
         }
-        public static String MakeVersionString(String kAppName)
+        public static string MakeVersionString(string kAppName)
         {
             string appver = GetAppVersion();
             StringBuilder sb = new StringBuilder();
@@ -25,7 +25,7 @@ namespace CTRE.Phoenix.dotNET.Form
             }
             return kAppName + " " + sb.ToString();
         }
-        public static bool ClipboardSet(String toCopy)
+        public static bool ClipboardSet(string toCopy)
         {
             try
             {

--- a/CTRE.Phoenix.dotNET/Form/ToggleButton.cs
+++ b/CTRE.Phoenix.dotNET/Form/ToggleButton.cs
@@ -6,11 +6,11 @@ namespace CTRE.Phoenix.dotNET.Form
     public class ToggleButton
     {
         Button _button;
-        String _notPressedText;
-        String _pressedText;
+        string _notPressedText;
+        string _pressedText;
         bool _isPressed;
 
-        public ToggleButton(Button button, bool IsPressed, String notPressedText, String pressedText)
+        public ToggleButton(Button button, bool IsPressed, string notPressedText, string pressedText)
         {
             _button = button;
             _notPressedText = notPressedText;

--- a/CTRE_Phoenix_GUI_Dashboard/DeviceListContainer.cs
+++ b/CTRE_Phoenix_GUI_Dashboard/DeviceListContainer.cs
@@ -82,7 +82,7 @@ namespace CTRE_Phoenix_GUI_Dashboard
             }
             return descriptor;
         }
-        bool AssignIfDiff(ListViewItem.ListViewSubItem lhs, String rhs)
+        bool AssignIfDiff(ListViewItem.ListViewSubItem lhs, string rhs)
         {
             if (lhs.Text.Equals(rhs))
             {

--- a/CTRE_Phoenix_GUI_Dashboard/ExportPackager.cs
+++ b/CTRE_Phoenix_GUI_Dashboard/ExportPackager.cs
@@ -35,7 +35,7 @@ namespace CTRE_Phoenix_GUI_Dashboard
             }
 
             /* Create directory for this specific Export */
-            string newExportPath = String.Format(".\\Exports\\Export {0}", DateTime.Now.ToString("yyyy-MM-dd HH.mm.ss"));
+            string newExportPath = string.Format(".\\Exports\\Export {0}", DateTime.Now.ToString("yyyy-MM-dd HH.mm.ss"));
             Directory.CreateDirectory(newExportPath);
 
             using (FileStream diagLog = new FileStream(newExportPath + "\\Diagnostic Log.txt", FileMode.Create))

--- a/CTRE_Phoenix_GUI_Dashboard/frmDashboard.cs
+++ b/CTRE_Phoenix_GUI_Dashboard/frmDashboard.cs
@@ -31,8 +31,8 @@ namespace CTRE_Phoenix_GUI_Dashboard {
         private BottomStatusBar _BottomStatusBar;
         private DeviceListContainer _deviceListContainer;
         int _guiTimeoutMs = 0;
-        private Object _guiStateLock = new Object();
-        private Object _deviceIDLock = new Object(); // TODO: this could be cleaned up using the regular action callback mechanism
+        private object _guiStateLock = new object();
+        private object _deviceIDLock = new object(); // TODO: this could be cleaned up using the regular action callback mechanism
         private bool _removeSelectedDevice = false; // TODO: this could be cleaned up using the regular action callback mechanism
         private struct ActionResponse {
             public BackEndAction action;
@@ -45,7 +45,7 @@ namespace CTRE_Phoenix_GUI_Dashboard {
         private ToggleButton _toggleWebPaused = null;
         private ToggleButton _toggleWebJumpToBtm = null;
         /* ----------- Constants -------- */
-        private readonly String kAppName = "Dashboard";
+        private readonly string kAppName = "Dashboard";
 
         public frmDashboard()
         {
@@ -78,7 +78,7 @@ namespace CTRE_Phoenix_GUI_Dashboard {
         }
 
         //--------------- Rendering GUI elements ---------------------------------//
-        Color DecodeMessageColor(String colorString)
+        Color DecodeMessageColor(string colorString)
         {
             switch (colorString[0]) {
                 case 'G':
@@ -402,7 +402,7 @@ namespace CTRE_Phoenix_GUI_Dashboard {
         {
             _BottomStatusBar.PrintRight(Color.Black, "Server Version: " + vers);
         }
-        private void PrintBackEndStatus(Color col, String text, String hoverMsg)
+        private void PrintBackEndStatus(Color col, string text, string hoverMsg)
         {
             _BottomStatusBar.SetHoverString(hoverMsg);
             _BottomStatusBar.PrintMiddleLeft(col, text);
@@ -428,7 +428,7 @@ namespace CTRE_Phoenix_GUI_Dashboard {
                 return false;
             return true;
         }
-        private void PrintConnectionStatus(Color col, String text)
+        private void PrintConnectionStatus(Color col, string text)
         {
             _BottomStatusBar.PrintRight(col, text);
         }
@@ -646,9 +646,9 @@ namespace CTRE_Phoenix_GUI_Dashboard {
             timer1.Interval = 40; /* 10ms => 40ms */
 
             /* get backup status, color, and hover message */
-            String msg, messageColor, hoverMsg;
+            string msg, messageColor, hoverMsg;
             BackEnd.State state = BackEnd.Instance.GetStatus(out msg, out messageColor, out hoverMsg);
-            String connectionStatus = BackEnd.Instance.GetConnectionStatus();
+            string connectionStatus = BackEnd.Instance.GetConnectionStatus();
 
             /* its up to the GUI how much of this stuff to show */
             PrintConnectionStatus(Color.Blue, connectionStatus);
@@ -964,7 +964,7 @@ namespace CTRE_Phoenix_GUI_Dashboard {
         //--------------------------------------------------------------------------------------------------//
         void GenerateTabs(DeviceDescrip dd, System.Windows.Forms.TabControl tabControl)
         {
-            String strNamespace = "CTRE_Phoenix_GUI_Dashboard"; // TODO: can this be retreived using reflection
+            string strNamespace = "CTRE_Phoenix_GUI_Dashboard"; // TODO: can this be retreived using reflection
             /* lots of missing error checking here */
 
             if (dd.configCache != null)
@@ -988,7 +988,7 @@ namespace CTRE_Phoenix_GUI_Dashboard {
         }
         void UpdateTabs(DeviceDescrip dd, TabControl tabControl)
         {
-            String strNamespace = "CTRE_Phoenix_GUI_Dashboard"; // TODO: can this be retreived using reflection
+            string strNamespace = "CTRE_Phoenix_GUI_Dashboard"; // TODO: can this be retreived using reflection
             /* lots of missing error checking here */
             int tabIndex = 1; //Index starts at one to pass over self test
 


### PR DESCRIPTION
The mix of Object and object / String and string was not good, there should be consistency. The standard in VS is all lowercase, so changed to that