### PR TITLE
Fixed Rio Detect after restart + Error report bug

### DIFF
--- a/CTRE.Phoenix.Diagnostics/BackEnd/BackEnd.cs
+++ b/CTRE.Phoenix.Diagnostics/BackEnd/BackEnd.cs
@@ -593,6 +593,8 @@ namespace CTRE.Phoenix.Diagnostics.BackEnd
                             /* if any transaction failed in the tool, something is wrong */
                             if (err != Status.Ok)
                             {
+								/* Clear devices from container to allow for rediscovery when RIO is found again */
+                                _descriptors.Clear();
                                 SetState(State.Connecting);
                             }
                             break;

--- a/CTRE.Phoenix.Diagnostics/DeviceDescriptors.cs
+++ b/CTRE.Phoenix.Diagnostics/DeviceDescriptors.cs
@@ -59,6 +59,10 @@ namespace CTRE.Phoenix.Diagnostics
 
             return existed;
         }
+        public void Clear()
+        {
+            _map.Clear();
+        }
         /// <summary>
         /// Creates a flat array with every element at the moment of the call.  This is useful
         /// for looping through each discovered ECU while removing stale ECUs in the inner loop.

--- a/CTRE.Phoenix.Diagnostics/RioFiles.cs
+++ b/CTRE.Phoenix.Diagnostics/RioFiles.cs
@@ -67,7 +67,6 @@ namespace CTRE.Phoenix.Diagnostics
         {
             new RioFile("Binary/ctre/Phoenix-diagnostics-server", "/usr/local/frc/bin/Phoenix-diagnostics-server"),
             new RioFile("Binary/etc/init.d/Phoenix-diagnostics-server", "/etc/init.d/Phoenix-diagnostics-server"),
-            new RioFile("Binary/etc/rc5.d/S25Phoenix-diagnostics-server", "/etc/rc5.d/S25Phoenix-diagnostics-server"),
             new RioFile("Binary/cci/libCTRE_PhoenixCCI.so", "/usr/local/frc/lib/libCTRE_PhoenixCCI.so"),
         };
     }

--- a/CTRE.Phoenix.Diagnostics/RioUpdater.cs
+++ b/CTRE.Phoenix.Diagnostics/RioUpdater.cs
@@ -366,6 +366,7 @@ namespace CTRE.Phoenix.Diagnostics
                     }
                 }
             }
+
             /* write new files  */
             if (error == 0)
             {
@@ -423,19 +424,14 @@ namespace CTRE.Phoenix.Diagnostics
                     
                     Log("Updating File Write Permissions");
                     term.SendCommand("chmod 777 /etc/init.d/Phoenix-diagnostics-server");
-                    term.SendCommand("chmod 777 /etc/rc5.d/S25Phoenix-diagnostics-server");
                     term.SendCommand("chmod 777 /usr/local/frc/bin/Phoenix-diagnostics-server");
-
 
                     //Wait a bit to make sure any file changes actually took
                     Thread.Sleep(1000);
                     Log("Syncing RoboRIO to ensure files are on the flash");
                     term.SendCommand("sync");
-                    
                 }
-                catch (Exception)
-                {
-                }
+                catch (Exception){ }
                 finally
                 {
                     if (term != null)
@@ -444,8 +440,31 @@ namespace CTRE.Phoenix.Diagnostics
                     }
                 }
             }
-            //Wait some more to allow sync ot take affect
+
+            /* Allow more time to ensure sync */
             Thread.Sleep(1000);
+
+            /* Create Symlink for Phoenix-diagnostics-server in etc/rc5.d/ */
+            if (error == 0)
+            {
+                CtrSshClient term = null;
+                try
+                {
+                    term = new CtrSshClient(_host, this);
+
+                    Log("Creating/Updating Symlink for rc5.d");
+                    term.SendCommand("ln -sf /etc/init.d/Phoenix-diagnostics-server /etc/rc5.d/S25Phoenix-diagnostics-server");
+                }
+                catch (Exception) { }
+                finally
+                {
+                    if (term != null)
+                    {
+                        term.Close();
+                    }
+                }
+            }
+
             /* restart server */
             if (error == 0)
             {
@@ -609,7 +628,5 @@ namespace CTRE.Phoenix.Diagnostics
                 ts.Milliseconds / 10);
             Log("\nDuration: " + elapsedTime);
         }
-
-
     }
 }

--- a/CTRE_Phoenix_GUI_Dashboard/DeviceListContainer.cs
+++ b/CTRE_Phoenix_GUI_Dashboard/DeviceListContainer.cs
@@ -15,6 +15,9 @@ namespace CTRE_Phoenix_GUI_Dashboard
     /// </summary>
     public class DeviceListContainer
     {
+        /* Device timeout before graying-out, Original value of 5 */
+        private double kDeviceTimeout = 2.5;    //Seconds
+
         private Dictionary<ListViewItem, DeviceDescrip> _mapDescriptors = new Dictionary<ListViewItem, DeviceDescrip>();
 
         private System.Windows.Forms.ListView lstDevices;
@@ -200,7 +203,7 @@ namespace CTRE_Phoenix_GUI_Dashboard
                     /* go to next one */
                     ++i;
 
-                    if (currentTimeStamp - oldDD.updateTimestamp > TimeSpan.FromSeconds(5))
+                    if (currentTimeStamp - oldDD.updateTimestamp > TimeSpan.FromSeconds(kDeviceTimeout))
                     {
                         // Old, gray it out
                         CTRE.Phoenix.dotNET.Form.FastUpdate.AssignIfDiff(oldListViewItem, System.Drawing.Color.Gray, System.Drawing.Color.LightGray);


### PR DESCRIPTION
+ Added command to create/update symlink for rc5.d, Logged
- Removed command/file for /etc/rc5.d, allow symlink to create it
Fixes https://github.com/CrossTheRoadElectronics/Phoenix-IssueTracker/issues/621
+ Added clear function for DeviceDescriptors, called whenever RIO or CAN Device is disconnected
Fixes https://github.com/CrossTheRoadElectronics/Phoenix-IssueTracker/issues/608
Fixes https://github.com/CrossTheRoadElectronics/Phoenix-IssueTracker/issues/609
- Reduced timeout for Device Status in Device List (time to gray out) from 5 -> 2.5